### PR TITLE
fix: [PL-23130]: enable gzip for js and css

### DIFF
--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -22,6 +22,7 @@ http {
 
     gzip on;
     gzip_disable "msie6";
+    gzip_types text/html application/javascript text/css;
 
     access_log /var/log/nginx/access.log;
     error_log /var/log/nginx/error.log;

--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -22,7 +22,7 @@ http {
 
     gzip on;
     gzip_disable "msie6";
-    gzip_types text/html application/javascript text/css;
+    gzip_types application/javascript text/css;
 
     access_log /var/log/nginx/access.log;
     error_log /var/log/nginx/error.log;


### PR DESCRIPTION
nginx only gzips html responses by default. in onprem, there is no CDN, so even static resources are getting loaded without gzip from app server, causing significant slowness.