### PR TITLE
fix: [GTM-801]: fix background img layout

### DIFF
--- a/src/components/BasicLayout/BasicLayout.module.css
+++ b/src/components/BasicLayout/BasicLayout.module.css
@@ -34,16 +34,16 @@
     padding-left: 0px;
 
     & .foreground {
-      position: absolute;
+      position: sticky;
       top: 25%;
-      left: 35%;
+      right: 0px;
       height: auto;
-      width: 65%;
+      width: 100%;
     }
   }
 }
 
-@media (max-width: 1520px) {
+@media (max-width: 1270px) {
   .layout {
     display: flex;
     justify-content: center;


### PR DESCRIPTION
this is to fix sign in/up background img layout so that its media max width doesn't have to change

Community:

https://user-images.githubusercontent.com/80717697/159347594-8b52f940-7def-40de-9c2b-f9773f19cf29.mov

Saas: 


https://user-images.githubusercontent.com/80717697/159347708-adc726ed-072a-42dc-8f0c-09ffde1281a0.mov




