### PR TITLE
feat: [GTM-1007]: add sign in and up telemetry events

### DIFF
--- a/src/pages/SignIn/SignIn.tsx
+++ b/src/pages/SignIn/SignIn.tsx
@@ -31,6 +31,8 @@ import { isCommunityPlan } from "utils/DeploymentTypeUtil";
 import Spinner from "static/icons/spinner/Spinner";
 import { useVanityExperience } from "hooks/useVanityExperience";
 import PasswordField from "components/Field/PasswordField";
+import telemetry from "telemetry/Telemetry";
+import { CATEGORY, EVENT } from "utils/TelemetryUtils";
 
 const createAuthToken = (email: string, password: string): string => {
   const encodedToken = btoa(email + ":" + password);
@@ -108,6 +110,15 @@ const SignIn: React.FC = () => {
   }, []);
 
   const handleLogin = async (formData: LoginFormData) => {
+    telemetry.track({
+      event: EVENT.SIGNIN_SUBMIT,
+      properties: {
+        category: CATEGORY.SIGNIN,
+        userId: formData.email,
+        groupId: formData.email
+      }
+    });
+
     try {
       const response = await login(
         {

--- a/src/pages/SignUp/SignUp.test.tsx
+++ b/src/pages/SignUp/SignUp.test.tsx
@@ -41,9 +41,7 @@ describe("SignUp", () => {
         name: PAGE.SIGNUP_PAGE,
         category: CATEGORY.SIGNUP,
         properties: {
-          userId: "",
-          groupId: "",
-          module: "ci",
+          intent: "ci",
           utm_campaign: "",
           utm_content: "",
           utm_medium: "",
@@ -62,8 +60,7 @@ describe("SignUp", () => {
         event: EVENT.EMAIL_INPUT,
         properties: {
           category: CATEGORY.SIGNUP,
-          userId: "random@hotmail.com",
-          groupId: "",
+          email: "random@hotmail.com",
           utm_campaign: "",
           utm_content: "",
           utm_medium: "",
@@ -84,7 +81,8 @@ describe("SignUp", () => {
         properties: {
           category: CATEGORY.SIGNUP,
           userId: "random@hotmail.com",
-          groupId: "",
+          intent: "ci",
+          groupId: "random@hotmail.com",
           utm_campaign: "",
           utm_content: "",
           utm_medium: "",

--- a/src/pages/SignUp/Signup.tsx
+++ b/src/pages/SignUp/Signup.tsx
@@ -147,9 +147,10 @@ const SignUp: React.FC = () => {
       telemetry.track({
         event: EVENT.SIGNUP_SUBMIT,
         properties: {
+          intent: module || "",
           category: CATEGORY.SIGNUP,
           userId: data.email,
-          groupId: "",
+          groupId: data.email,
           utm_source: utm_source || "",
           utm_medium: utm_medium || "",
           utm_campaign: utm_campaign || "",
@@ -172,8 +173,7 @@ const SignUp: React.FC = () => {
           event: EVENT.EMAIL_INPUT,
           properties: {
             category: CATEGORY.SIGNUP,
-            userId: e.target.value,
-            groupId: "",
+            email: e.target.value,
             utm_source: utm_source || "",
             utm_medium: utm_medium || "",
             utm_campaign: utm_campaign || "",
@@ -195,20 +195,20 @@ const SignUp: React.FC = () => {
     />
   );
 
-  telemetry.page({
-    name: PAGE.SIGNUP_PAGE,
-    category: CATEGORY.SIGNUP,
-    properties: {
-      userId: "",
-      groupId: "",
-      module: module || "",
-      utm_source: utm_source || "",
-      utm_medium: utm_medium || "",
-      utm_campaign: utm_campaign || "",
-      utm_term: utm_term || "",
-      utm_content: utm_content || ""
-    }
-  });
+  useEffect(() => {
+    telemetry.page({
+      name: PAGE.SIGNUP_PAGE,
+      category: CATEGORY.SIGNUP,
+      properties: {
+        intent: module || "",
+        utm_source: utm_source || "",
+        utm_medium: utm_medium || "",
+        utm_campaign: utm_campaign || "",
+        utm_term: utm_term || "",
+        utm_content: utm_content || ""
+      }
+    });
+  }, []);
 
   function handleRecaptchaError() {
     // Block the user until they refresh

--- a/src/pages/VerifyEmail/VerifyEmail.test.tsx
+++ b/src/pages/VerifyEmail/VerifyEmail.test.tsx
@@ -59,7 +59,8 @@ describe("Verify Email", () => {
           event: EVENT.RESEND_VERIFY_EMAIL,
           properties: {
             category: CATEGORY.SIGNUP,
-            userId: "random@harness.io"
+            userId: "random@harness.io",
+            groupId: "random@harness.io"
           }
         });
         expect(getByText(EMAIL_VERIFY_STATUS.EMAIL_SENT)).toBeDefined();

--- a/src/pages/VerifyEmail/VerifyEmailStatus.tsx
+++ b/src/pages/VerifyEmail/VerifyEmailStatus.tsx
@@ -53,7 +53,8 @@ const ResendButton = (props: ResendButtonProps): React.ReactElement => {
         event: EVENT.RESEND_VERIFY_EMAIL,
         properties: {
           category: CATEGORY.SIGNUP,
-          userId: email
+          userId: email,
+          groupId: email
         }
       });
       await resendVerifyEmail();

--- a/src/utils/LoginUtils.ts
+++ b/src/utils/LoginUtils.ts
@@ -63,7 +63,9 @@ export function handleLoginSuccess({
     SecureStorage.setItem("lastTokenSetTime", new Date().getTime());
 
     // send identify user event to telemetry to update the identity
-    resource.email && telemetry.identify(resource.email);
+    if (resource.email) {
+      telemetry.identify(resource.email);
+    }
 
     if (
       resource.twoFactorAuthenticationEnabled === true &&

--- a/src/utils/LoginUtils.ts
+++ b/src/utils/LoginUtils.ts
@@ -63,7 +63,7 @@ export function handleLoginSuccess({
     SecureStorage.setItem("lastTokenSetTime", new Date().getTime());
 
     // send identify user event to telemetry to update the identity
-    telemetry.identify(resource.email || "");
+    resource.email && telemetry.identify(resource.email);
 
     if (
       resource.twoFactorAuthenticationEnabled === true &&

--- a/src/utils/SignUpUtils.ts
+++ b/src/utils/SignUpUtils.ts
@@ -22,7 +22,9 @@ export async function handleSignUpSuccess(resource?: UserInfo): Promise<void> {
     SecureStorage.setItem("lastTokenSetTime", new Date().getTime());
 
     // send identify user event to telemetry to update the identity
-    resource.email && telemetry.identify(resource.email);
+    if (resource.email) {
+      telemetry.identify(resource.email);
+    }
 
     // Disabling this to avoid overloading LS with Harness Support usergroup accounts
     // https://harness.atlassian.net/browse/PL-20761

--- a/src/utils/SignUpUtils.ts
+++ b/src/utils/SignUpUtils.ts
@@ -22,7 +22,7 @@ export async function handleSignUpSuccess(resource?: UserInfo): Promise<void> {
     SecureStorage.setItem("lastTokenSetTime", new Date().getTime());
 
     // send identify user event to telemetry to update the identity
-    telemetry.identify(resource.email || "");
+    resource.email && telemetry.identify(resource.email);
 
     // Disabling this to avoid overloading LS with Harness Support usergroup accounts
     // https://harness.atlassian.net/browse/PL-20761

--- a/src/utils/TelemetryUtils.ts
+++ b/src/utils/TelemetryUtils.ts
@@ -6,16 +6,16 @@
  */
 
 export enum EVENT {
-  SIGNUP_SUBMIT = "SIGNUP_SUBMIT",
-  EMAIL_INPUT = "EMAIL_INPUT",
-  RESEND_VERIFY_EMAIL = "RESEND_VERIFY_EMAIL",
-  OAUTH_SIGNUP = "OAUTH_SIGNUP"
+  SIGNUP_SUBMIT = "Signup Submitted",
+  EMAIL_INPUT = "Email inputted",
+  RESEND_VERIFY_EMAIL = "Verify email resent",
+  OAUTH_SIGNUP = "Oauth Signup clicked"
 }
 
 export enum CATEGORY {
-  SIGNUP = "SIGNUP"
+  SIGNUP = "Signup"
 }
 
 export enum PAGE {
-  SIGNUP_PAGE = "SIGNUP_PAGE"
+  SIGNUP_PAGE = "Signup"
 }

--- a/src/utils/TelemetryUtils.ts
+++ b/src/utils/TelemetryUtils.ts
@@ -6,14 +6,16 @@
  */
 
 export enum EVENT {
-  SIGNUP_SUBMIT = "Signup Submitted",
+  SIGNUP_SUBMIT = "Signup submitted",
+  SIGNIN_SUBMIT = "Signin submitted",
   EMAIL_INPUT = "Email inputted",
   RESEND_VERIFY_EMAIL = "Verify email resent",
-  OAUTH_SIGNUP = "Oauth Signup clicked"
+  OAUTH_CLICKED = "Oauth clicked"
 }
 
 export enum CATEGORY {
-  SIGNUP = "Signup"
+  SIGNUP = "Signup",
+  SIGNIN = "Signin"
 }
 
 export enum PAGE {


### PR DESCRIPTION
this is to add more telemetry track events when users sign in and up

 `pagehide` is recommended instead of `beforeunload` according to the references. 
`beforeunload` doesn't fire from android browser, but for harness app, android browser would be rarely within the scope.
meanwhile, `pagehide` is not working when testing for unknown reason, hence `beforeunload` is used here.



https://user-images.githubusercontent.com/80717697/166480576-06c127f9-23f1-42d5-bb54-6eaf7bf8f402.mov



reference:
https://www.igvita.com/2015/11/20/dont-lose-user-and-app-state-use-page-visibility/
https://developer.chrome.com/blog/page-lifecycle-api/#legacy-lifecycle-apis-to-avoid
https://developer.chrome.com/blog/page-lifecycle-api/#the-beforeunload-event