### PR TITLE
feat: [GTM-1058]: make sure view page event gets fired

### DIFF
--- a/src/pages/SignUp/SignUp.test.tsx
+++ b/src/pages/SignUp/SignUp.test.tsx
@@ -17,7 +17,8 @@ const trackMock = jest.fn();
 
 jest.mock("telemetry/Telemetry", () => ({
   page: jest.fn().mockImplementation((values) => pageMock(values)),
-  track: jest.fn().mockImplementation((values) => trackMock(values))
+  track: jest.fn().mockImplementation((values) => trackMock(values)),
+  initialized: true
 }));
 
 describe("SignUp", () => {

--- a/src/pages/SignUp/Signup.tsx
+++ b/src/pages/SignUp/Signup.tsx
@@ -203,19 +203,21 @@ const SignUp: React.FC = () => {
   );
 
   useEffect(() => {
-    telemetry.page({
-      name: PAGE.SIGNUP_PAGE,
-      category: CATEGORY.SIGNUP,
-      properties: {
-        intent: module || "",
-        utmSource,
-        utmContent,
-        utmMedium,
-        utmTerm,
-        utmCampaign
-      }
-    });
-  }, []);
+    if (telemetry.initialized) {
+      telemetry.page({
+        name: PAGE.SIGNUP_PAGE,
+        category: CATEGORY.SIGNUP,
+        properties: {
+          intent: module || "",
+          utmSource,
+          utmContent,
+          utmMedium,
+          utmTerm,
+          utmCampaign
+        }
+      });
+    }
+  }, [telemetry.initialized]);
 
   function handleRecaptchaError() {
     // Block the user until they refresh

--- a/src/telemetry/Telemetry.ts
+++ b/src/telemetry/Telemetry.ts
@@ -10,7 +10,8 @@ import Telemetry from "@harness/telemetry";
 const stubTelemetry = {
   identify: () => void 0,
   track: () => void 0,
-  page: () => void 0
+  page: () => void 0,
+  initialized: false
 };
 
 const TelemetryInstance =


### PR DESCRIPTION
this is to make sure that `view signup page` is fired

today telemetry is loaded on sign up page if this is the first page that user lands on. without the change, a lot of times this view page event fails getting fired due to telemetry not fully initialized yet.

the fix will make sure that this event is fired.