### PR TITLE
fix: [PLG-1189]: Telemetry package upgrade and anchor tag redirection props

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "homepage": "https://github.com/harness/harness-auth-ui#readme",
   "dependencies": {
-    "@harness/telemetry": "^1.0.42",
+    "@harness/telemetry": "^1.0.44",
     "classnames": "^2.2.6",
     "normalize.css": "^8.0.1",
     "purecss": "^2.0.5",

--- a/src/pages/SignUp/SaasExperimentalForms/SignUpExperimental.tsx
+++ b/src/pages/SignUp/SaasExperimentalForms/SignUpExperimental.tsx
@@ -92,6 +92,7 @@ const SignUpExperimental: React.FC = () => {
     captchaToken: string
   ): Promise<void> => {
     const encodedEmail = encodeURIComponent(data.email);
+
     try {
       const signupRequestData: SignupDTO = {
         ...data,
@@ -229,11 +230,21 @@ const SignUpExperimental: React.FC = () => {
 
         <p className={css.agreement}>
           By signing up, you agree to our
-          <a href={URLS.PRIVACY_AGREEMENT} className={css.link}>
+          <a
+            href={URLS.PRIVACY_AGREEMENT}
+            className={css.link}
+            rel="noreferrer"
+            target="_blank"
+          >
             Privacy Policy
           </a>
           and our
-          <a href={URLS.SUBSCRIPTION_TERMS} className={css.link}>
+          <a
+            href={URLS.SUBSCRIPTION_TERMS}
+            className={css.link}
+            rel="noreferrer"
+            target="_blank"
+          >
             Terms of Use
           </a>
         </p>

--- a/src/pages/SignUp/SaasExperimentalForms/utils.ts
+++ b/src/pages/SignUp/SaasExperimentalForms/utils.ts
@@ -91,7 +91,7 @@ const MODULE_TO_DETAILS_MAP: ModuleDetailsMap = {
     cta: "Connect Cloud Account",
     color: "#01C9CC"
   },
-  ff: {
+  cf: {
     logo: FFLogo,
     pathImg: PathFF,
     title: "Feature Flags",

--- a/src/pages/SignUp/SaasExperimentalForms/utils.ts
+++ b/src/pages/SignUp/SaasExperimentalForms/utils.ts
@@ -71,7 +71,7 @@ const MODULE_TO_DETAILS_MAP: ModuleDetailsMap = {
     valueProp:
       "An intelligent, container-native CI solution with isolated builds and standardized extensions. Build artifacts smarter and faster.",
     callout:
-      "Trusted by the New York Times, Roblox, John Deere, eBay and many others to run their build and test suits balzing fast",
+      "TRUSTED BY THE NEW YORK TIMES, ROBLOX, JOHN DEERE, EBAY AND MANY OTHERS TO RUN THEIR BUILDS AND TEST SUITES BLAZING FAST",
     intro:
       "Create a container-based build pipeline in minutes. Even testing is lightweight and fast with Test Intelligence!",
     cta: "Let's build",

--- a/yarn.lock
+++ b/yarn.lock
@@ -528,6 +528,11 @@
   resolved "https://npm.pkg.github.com/download/@harness/telemetry/1.0.42/60bc34c133bb40f0e0aa08f80620a1b23f3f089070e8550767e9d3fce8ca6e25#4d3f71026a03c898992d902f13a6c6d9cb0edac6"
   integrity sha512-pwjPYnQ8du1UswlX7A/apewGVDmbmaKKWTQSXtSHhKf9ekZ8WCwVvFcrM8ZIq/QbTn7Z8BXFYtMJdSG25oNtOg==
 
+"@harness/telemetry@^1.0.44":
+  version "1.0.44"
+  resolved "https://npm.pkg.github.com/download/@harness/Telemetry/1.0.44/5003ae3152149b54b9084f38a8369830dde8038d33aa5317699facb3d4262d93#55e75d8caccbcdcb0a11226c813edd631578d9af"
+  integrity sha512-t6N3Ie/F9Nw/tANAmptsunebGYBkC3j865bc75MZVL2ZqFM0CBRxFR1MG8zC+hU6uDpr8Drqsn81NmdlVlBSmA==
+
 "@istanbuljs/load-nyc-config@^1.0.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz#fd3db1d59ecf7cf121e80650bb86712f9b55eced"


### PR DESCRIPTION
This PR fixes the issue with `Telemetry` events not being queued in `segment queue` and also includes a minor fix for `Privacy Policy` and `Term of use` not being opened in a new browser tab
JIRA Ticket:
https://harness.atlassian.net/browse/PLG-1189