### PR TITLE
fix: [PLG-1189]: Removed category from Signup Page Event

### DIFF
--- a/src/pages/SignUp/SaasExperimentalForms/SignUpExperimental.tsx
+++ b/src/pages/SignUp/SaasExperimentalForms/SignUpExperimental.tsx
@@ -180,7 +180,6 @@ const SignUpExperimental: React.FC = () => {
   useEffect(() => {
     telemetry.page({
       name: PAGE.SIGNUP_PAGE,
-      category: CATEGORY.SIGNUP,
       properties: {
         intent: module || "",
         utm_source: utm_source || "",


### PR DESCRIPTION
This PR removed `category` props from Signup Page Event which is requested in https://harness.atlassian.net/browse/PLG-1189